### PR TITLE
Handling of NAs (Fix #106)

### DIFF
--- a/R/1_functions4Fitting.R
+++ b/R/1_functions4Fitting.R
@@ -583,6 +583,7 @@ rmarkovchain <- function(n, object, what = "data.frame", useRCpp = TRUE, paralle
 #' @param byrow Indicates whether distinc stochastic processes trajectiories are shown in distinct rows.
 #' @param name Optional name.
 #' 
+#' @details If \code{data} contains \code{NAs} then the transitions containing \code{NA} will be ignored.
 #' @return A list containing two slots:
 #' estimate (the estimate)
 #' name

--- a/R/1_functions4Fitting.R
+++ b/R/1_functions4Fitting.R
@@ -604,85 +604,57 @@ markovchainListFit <- function(data, byrow = TRUE, laplacian = 0, name) {
     stop("Error: data must be either a matrix or a data.frame or a list")
   }
   
+  freqMatrixes <- list() 
+  
   if(class(data) == "list") {
     markovchains <- list()
     # list of frquency matrix
-    out <- .mcListFitForList(data)
-    l <- length(out)
+    freqMatrixes <- .mcListFitForList(data)
     
-    # no transition at all
-    if(l == 0) {
-      return(markovchains)
+  } else{
+    # if input is data frame convert it to matrix
+    if(is.data.frame(data)) {
+      data <- unname(as.matrix(data))
     }
     
-    for(i in 1:l) {
-      freqMatrix <- out[[i]]
-      # add laplacian correction
-      freqMatrix <- freqMatrix + laplacian
-      rSums <- rowSums(freqMatrix)
-      # transition matrix
-      tMatrix <- freqMatrix / rSums;
+    # make the entries row wise if it is not
+    if(!byrow) {
+      data <- t(data) 
+    }
+    
+    # number of columns in the matrix
+    nCols <- ncol(data)
+    
+    # fit by columns
+    freqMatrixes <- lapply(seq_len(nCols-1), function(i){
+      # (i-1)th transition matrix for transition from (i-1)th state to ith state
+      matrData <- data[, c(i, i+1)]
+      matrData[1, ] <- as.character(matrData[1, ])
+      validTransition <- any(apply(matrData, 1, function(x){ !any(is.na(x)) }))
       
-      estMc <- new("markovchain", transitionMatrix = tMatrix)
-      markovchains[[i]] <- estMc
-    }
+      if(validTransition)
+        createSequenceMatrix(matrData, toRowProbs = FALSE, sanitize = TRUE)
     
-    # create markovchainList object
-    outMcList <- new("markovchainList", markovchains = markovchains)
+    })
     
-    # wrap the object in a list
-    result <- list(estimate = outMcList)
-    
-    # set the name of markovchainList object as given in the argument
-    if(!missing(name)) {
-      result$estimate@name <- name 
-    }
-    
-    return(result)
+    freqMatrixes <- freqMatrixes[ !sapply(freqMatrixes, is.null) ]
   }
   
-  # if input is data frame convert it to matrix
-  if(is.data.frame(data)) {
-    data <- as.matrix(data)
-  } 
-  
-  # make the entries row wise if it is not
-  if(!byrow) {
-    data <- t(data) 
+  if(length(freqMatrixes) == 0) {
+    return(list())
   }
   
-  # number of columns in the matrix
-  nCols <- ncol(data)
   
-  # allocate a list of markovchain: a non - homog DTMC process is a 
-  # list of DTMC of length n-1, being n the length of the sequence
-  markovchains <- list() 
-  
-  # fit by columns
-  for(i in 2:(nCols)) { 
-    
-    # (i-1)th transition matrix for transition from (i-1)th state to ith state
-    matrData <- data[, c(i-1, i)]
-    matrData[1, ] <- as.character(matrData[1, ])
-    freqMatrix <- createSequenceMatrix(matrData, toRowProbs = FALSE, sanitize = TRUE)
-    
+  markovchains <- lapply(freqMatrixes, function(freqMatrix){
     # add laplacian correction
     freqMatrix <- freqMatrix + laplacian
     rSums <- rowSums(freqMatrix)
-    
     # transition matrix
     tMatrix <- freqMatrix / rSums;
     
     estMc <- new("markovchain", transitionMatrix = tMatrix)
-    
-    # give name to the markovchain object which is same as the name of (i-1)th column
-    if(!is.null(colnames(data))) {
-      estMc@name <- colnames(data)[i-1]  
-    }
-    
-    # store one transition matrix at every iteration
-    markovchains[[i-1]] <- estMc
-  }
+    estMc
+  })
   
   # create markovchainList object
   outMcList <- new("markovchainList", markovchains = markovchains)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -130,7 +130,8 @@ inferHyperparam <- function(transMatr = matrix(), scale = numeric(), data = char
 #' @param sanitize put 1 in all rows having rowSum equal to zero
 #' @param possibleStates Possible states which are not present in the given sequence
 #' 
-#' @details Disabling confint would lower the computation time on large datasets
+#' @details Disabling confint would lower the computation time on large datasets. If \code{data} or \code{stringchar} 
+#' contain \code{NAs}, the related \code{NA} containing transitions will be ignored.
 #' 
 #' @return A list containing an estimate, log-likelihood, and, when "bootstrap" method is used, a matrix 
 #'         of standards deviations and the bootstrap samples. When the "mle", "bootstrap" or "map" method 
@@ -160,6 +161,10 @@ inferHyperparam <- function(transMatr = matrix(), scale = numeric(), data = char
 #' mcFitMLE <- markovchainFit(data = sequence)
 #' mcFitBSP <- markovchainFit(data = sequence, method = "bootstrap", nboot = 5, name = "Bootstrap Mc")
 #'
+#' na.sequence <- c("a", NA, "a", "b")
+#' # There will be only a (a,b) transition        
+#' na.sequenceMatr <- createSequenceMatrix(na.sequence, sanitize = FALSE)
+#' mcFitMLE <- markovchainFit(data = na.sequence)
 #' @rdname markovchainFit
 #' 
 #' @export

--- a/man/markovchainFit.Rd
+++ b/man/markovchainFit.Rd
@@ -60,7 +60,8 @@ Given a sequence of states arising from a stationary state,
  Laplacian smoother), bootstrap or by MAP (Bayesian) inference.
 }
 \details{
-Disabling confint would lower the computation time on large datasets
+Disabling confint would lower the computation time on large datasets. If \code{data} or \code{stringchar} 
+contain \code{NAs}, the related \code{NA} containing transitions will be ignored.
 }
 \note{
 This function has been rewritten in Rcpp. Bootstrap algorithm has been defined "euristically". 
@@ -75,6 +76,10 @@ sequenceMatr <- createSequenceMatrix(sequence, sanitize = FALSE)
 mcFitMLE <- markovchainFit(data = sequence)
 mcFitBSP <- markovchainFit(data = sequence, method = "bootstrap", nboot = 5, name = "Bootstrap Mc")
 
+na.sequence <- c("a", NA, "a", "b")
+# There will be only a (a,b) transition        
+na.sequenceMatr <- createSequenceMatrix(na.sequence, sanitize = FALSE)
+mcFitMLE <- markovchainFit(data = na.sequence)
 }
 \references{
 A First Course in Probability (8th Edition), Sheldon Ross, Prentice Hall 2010

--- a/man/markovchainListFit.Rd
+++ b/man/markovchainListFit.Rd
@@ -26,6 +26,9 @@ the temporal sequence), it fits a non - homogeneous discrete time markov chain
 process (storing row). In particular a markovchainList of size = ncol - 1 is obtained
 estimating transitions from the n samples given by consecutive column pairs.
 }
+\details{
+If \code{data} contains \code{NAs} then the transitions containing \code{NA} will be ignored.
+}
 \examples{
 
 # using holson dataset

--- a/src/1_functions4Fitting.cpp
+++ b/src/1_functions4Fitting.cpp
@@ -493,9 +493,9 @@ NumericMatrix createSequenceMatrix(SEXP stringchar, bool toRowProbs = false, boo
     for(int i = 0;i < possibleStates.size();i++) {
       pstates.push_back(possibleStates[i]);
     }
-    
     pstates = unique(pstates);
     pstates = pstates.sort();
+    
     int sizeMatr = pstates.size();
     NumericMatrix freqMatrix(sizeMatr);
     freqMatrix.attr("dimnames") = List::create(pstates, pstates);
@@ -518,6 +518,7 @@ NumericMatrix createSequenceMatrix(SEXP stringchar, bool toRowProbs = false, boo
     
     if(toRowProbs == true)
       return _toRowProbs(freqMatrix, sanitize);
+      
     
     return freqMatrix;
   }
@@ -529,14 +530,7 @@ NumericMatrix createSequenceMatrix(SEXP stringchar, bool toRowProbs = false, boo
   CharacterVector elements_na = unique(union_(stringChar, possibleStates));
   
   // free from missing values
-  CharacterVector elements;
-  
-  for(int i = 0; i < elements_na.size();i++) {
-    if(elements_na[i] != "NA") {
-      elements.push_back(elements_na[i]);
-    }
-  }
-  
+  CharacterVector elements = clean_nas(elements_na);
   elements = elements.sort();
   int sizeMatr = elements.size();
   
@@ -571,12 +565,14 @@ NumericMatrix createSequenceMatrix(SEXP stringchar, bool toRowProbs = false, boo
     
     int posFrom = 0, posTo = 0;
     for(long int i = 0; i < stringChar.size() - 1; i ++) {
-      for (int j = 0; j < rnames.size(); j ++) {
-        if(stringChar[i] == rnames[j]) posFrom = j;
-        if(stringChar[i + 1] == rnames[j]) posTo = j;
+      if(stringChar[i] != "NA" && stringChar[i+1] != "NA"){
+        for (int j = 0; j < rnames.size(); j ++) {
+          if(stringChar[i] == rnames[j]) posFrom = j;
+          if(stringChar[i + 1] == rnames[j]) posTo = j;
+        }
+        freqMatrix(posFrom, posTo)++;
       }
-      freqMatrix(posFrom, posTo)++;
-    }  
+    }
   }
   
   // sanitizing if any row in the matrix sums to zero by posing the corresponding diagonal equal to 1/dim
@@ -594,9 +590,8 @@ NumericMatrix createSequenceMatrix(SEXP stringchar, bool toRowProbs = false, boo
   
   if(toRowProbs == true)
     return _toRowProbs(freqMatrix, sanitize);
-  
+
   return (freqMatrix);
-  
 }
 
 // log-likelihood
@@ -611,11 +606,13 @@ double _loglikelihood(CharacterVector seq, NumericMatrix transMatr) {
   // caculate out
   int from = 0, to = 0; 
   for(long int i = 0; i < seq.size() - 1; i ++) {
-    for(int r = 0; r < rnames.size(); r ++) {
-      if(rnames[r] == seq[i]) from = r; 
-      if(rnames[r] == seq[i + 1]) to = r; 
-    }    
-    out += log(transMatr(from, to));
+    if(seq[i] != "NA" && seq[i+1] != "NA"){
+      for(int r = 0; r < rnames.size(); r ++) {
+        if(rnames[r] == seq[i]) from = r; 
+        if(rnames[r] == seq[i + 1]) to = r; 
+      }      
+      out += log(transMatr(from, to));
+    }
   }
   
   return out;
@@ -789,6 +786,7 @@ List _mcFitMle(SEXP data, bool byrow, double confidencelevel, bool sanitize = fa
   // create markov chain object
   S4 outMc("markovchain");
   outMc.slot("transitionMatrix") = initialMatr;
+  
   outMc.slot("name") = "MLE Fit";  
   
   List CI = generateCI(confidencelevel, freqMatr);
@@ -1156,9 +1154,10 @@ S4 _matr2Mc(CharacterMatrix matrData, double laplacian = 0, bool sanitize = fals
   
   // populate uniqueVals set
   for(long int i = 0; i < nRows; i++) 
-    for(long int j = 0; j < nCols; j++) 
-      uniqueVals.insert((std::string)matrData(i, j));	
-  
+    for(long int j = 0; j < nCols; j++){
+      if(matrData(i,j) != "NA")
+        uniqueVals.insert((std::string)matrData(i, j));	
+    }
   // unique states
   int usize = uniqueVals.size();
   
@@ -1175,20 +1174,21 @@ S4 _matr2Mc(CharacterMatrix matrData, double laplacian = 0, bool sanitize = fals
   int stateBegin = 0, stateEnd = 0;
   for(long int i = 0; i < nRows; i ++) {
     for(long int j = 1; j < nCols; j ++) {
+      if(matrData(i,j-1) != "NA" && matrData(i,j) != "NA"){
+        // row and column number of begin state and end state
+        int k = 0;
+        for(it = uniqueVals.begin(); it != uniqueVals.end(); ++it, k++) {
+          if(*it == (std::string)matrData(i, j-1)) {
+            stateBegin = k;
+          }
+          
+          if(*it == (std::string)matrData(i,j)) {
+            stateEnd = k;
+          }
+        }
       
-      // row and column number of begin state and end state
-      int k = 0;
-      for(it = uniqueVals.begin(); it != uniqueVals.end(); ++it, k++) {
-        if(*it == (std::string)matrData(i, j-1)) {
-          stateBegin = k;
-        }
-        
-        if(*it == (std::string)matrData(i,j)) {
-          stateEnd = k;
-        }
+        contingencyMatrix(stateBegin,stateEnd)++;
       }
-      
-      contingencyMatrix(stateBegin,stateEnd)++;
     }
   }
   
@@ -1593,7 +1593,7 @@ List markovchainFit(SEXP data, String method = "mle", bool byrow = true, int nbo
   	  }
   	  
   	  out = _mcFitMle(manyseq, byrow, confidencelevel, sanitize, possibleStates);
-  	  out[0] = outMc;  
+  	  out[0] = outMc;
   	} else {
   	  out = List::create(_["estimate"] = outMc);
   	}
@@ -1601,7 +1601,7 @@ List markovchainFit(SEXP data, String method = "mle", bool byrow = true, int nbo
   else if(TYPEOF(data) == VECSXP) { 
     out = _mcFitMle(data, byrow, confidencelevel, sanitize, possibleStates);
   }
-  else {    
+  else {
     if(method == "mle") {
       out = _mcFitMle(data, byrow, confidencelevel, sanitize, possibleStates);
     }

--- a/src/1_functions4Fitting.cpp
+++ b/src/1_functions4Fitting.cpp
@@ -645,13 +645,22 @@ List mcListFitForList(List data) {
     if(i < len) {
       // transition from (i-1)th to ith
       CharacterMatrix temp(l-j, 2);
+      // indicates wheter there is a valid transition for the current time of the
+      // markov chain
+      bool validTransition = false;
+      
       for(int k = j;k < l;k++) {
         temp(k-j, 0) = (as<CharacterVector>(data[length_seq[k].second]))[i-1];
         temp(k-j, 1) = (as<CharacterVector>(data[length_seq[k].second]))[i];
+        
+        if(temp(k-j,0) != "NA" && temp(k-j, 1) != "NA")
+          validTransition = true;
       }
       
       // frequency matrix
-      out.push_back(createSequenceMatrix(temp, false, true));
+      if(validTransition)
+        out.push_back(createSequenceMatrix(temp, false, true));
+      
       i++;
       
     } else {

--- a/src/1_functions4Fitting.cpp
+++ b/src/1_functions4Fitting.cpp
@@ -1512,7 +1512,8 @@ List inferHyperparam(NumericMatrix transMatr = NumericMatrix(), NumericVector sc
 //' @param sanitize put 1 in all rows having rowSum equal to zero
 //' @param possibleStates Possible states which are not present in the given sequence
 //' 
-//' @details Disabling confint would lower the computation time on large datasets
+//' @details Disabling confint would lower the computation time on large datasets. If \code{data} or \code{stringchar} 
+//' contain \code{NAs}, the related \code{NA} containing transitions will be ignored.
 //' 
 //' @return A list containing an estimate, log-likelihood, and, when "bootstrap" method is used, a matrix 
 //'         of standards deviations and the bootstrap samples. When the "mle", "bootstrap" or "map" method 
@@ -1542,6 +1543,10 @@ List inferHyperparam(NumericMatrix transMatr = NumericMatrix(), NumericVector sc
 //' mcFitMLE <- markovchainFit(data = sequence)
 //' mcFitBSP <- markovchainFit(data = sequence, method = "bootstrap", nboot = 5, name = "Bootstrap Mc")
 //'
+//' na.sequence <- c("a", NA, "a", "b")
+//' # There will be only a (a,b) transition        
+//' na.sequenceMatr <- createSequenceMatrix(na.sequence, sanitize = FALSE)
+//' mcFitMLE <- markovchainFit(data = na.sequence)
 //' @rdname markovchainFit
 //' 
 //' @export

--- a/src/mapFitFunctionsSAI.h
+++ b/src/mapFitFunctionsSAI.h
@@ -1,10 +1,27 @@
+/*
+ * @param elements_na vector that could contain NA values
+ * @return vector without NA values
+ */
+
+CharacterVector clean_nas(CharacterVector elements_na){
+  CharacterVector elements;
+    
+  for(int i = 0; i < elements_na.size();i++)
+    if(elements_na[i] != "NA")
+      elements.push_back(elements_na[i]);
+
+  return elements;
+}
+  
+
 List _mcFitMap(CharacterVector stringchar, bool byrow, double confidencelevel, NumericMatrix hyperparam = NumericMatrix(), 
                bool sanitize = false, CharacterVector possibleStates = CharacterVector()) {
   
+  // vector that could contain NA values
+  CharacterVector elements_na = stringchar;
+  elements_na = unique(union_(elements_na, possibleStates)).sort();
   // vector to store unique states in sorted order
-  CharacterVector elements = stringchar;
-  elements = unique(union_(elements, possibleStates)).sort();
-  
+  CharacterVector elements = clean_nas(elements_na);
   // number of unique states
   int sizeMatr = elements.size();
   
@@ -119,11 +136,13 @@ List _mcFitMap(CharacterVector stringchar, bool byrow, double confidencelevel, N
   // populate frequeny matrix for old data; this is used for inference 
   int posFrom = 0, posTo = 0;
   for(long int i = 0; i < stringchar.size() - 1; i ++) {
-    for (int j = 0; j < sizeMatr; j ++) {
-      if(stringchar[i] == elements[j]) posFrom = j;
-      if(stringchar[i + 1] == elements[j]) posTo = j;
+    if(stringchar[i] != "NA" && stringchar[i+1] != "NA"){
+      for (int j = 0; j < sizeMatr; j ++) {
+        if(stringchar[i] == elements[j]) posFrom = j;
+        if(stringchar[i + 1] == elements[j]) posTo = j;
+      }
+      freqMatr(posFrom,posTo)++;
     }
-    freqMatr(posFrom,posTo)++;
   }
  
   // sanitize and to row probs

--- a/src/mapFitFunctionsSAI.h
+++ b/src/mapFitFunctionsSAI.h
@@ -1,6 +1,5 @@
 /*
- * @param elements_na vector that could contain NA values
- * @return vector without NA values
+ * Function to remove NA values from a vector
  */
 
 CharacterVector clean_nas(CharacterVector elements_na){

--- a/tests/testthat/testBasic1.R
+++ b/tests/testthat/testBasic1.R
@@ -44,9 +44,10 @@ test_that("Conversion of objects",
             expect_equal(class(provaMatr2Mc)=="markovchain",TRUE)
           })
 
+
 ### Markovchain Fitting
-sequence1 <- c("a", "b", "a", "a", "a")
-sequence2 <- c("a", "b", "a", "a", "a", "a", "b", "a", "b", "a", "b", "a", "a", "b", "b", "b", "a")
+sequence1 <- c("a", "b", "a", "a", NA, "a", "a", NA)
+sequence2 <- c(NA, "a", "b", NA, "a", "a", "a", NA, "a", "b", "a", "b", "a", "b", "a", "a", "b", "b", "b", "a", NA)
 mcFit <- markovchainFit(data = sequence1, byrow = FALSE, sanitize = TRUE)
 mcFit2 <- markovchainFit(c("a","b","a","b"), sanitize = TRUE)
 
@@ -55,8 +56,9 @@ test_that("Fit should satisfy", {
   expect_equal(markovchainFit(data = sequence2, method = "bootstrap")["confidenceInterval"]
                [[1]]["confidenceLevel"][[1]], 0.95)
   expect_equal(mcFit2$upperEndpointMatrix, matrix(c(0,1,1,0), nrow = 2, byrow = TRUE,
-                                                dimnames = list(c("a", "b"), c("a", "b"))))
+                                                  dimnames = list(c("a", "b"), c("a", "b"))))
 })
+
 
 ### Markovchain Fitting for bigger markov chain
 bigseq <- rep(c("a", "b", "c"), 500000)
@@ -76,14 +78,15 @@ test_that("MC Fit for large sequence 2", {
   expect_equal(bigmcFit$estimate@transitionMatrix, bigmcFit$upperEndpointMatrix)
 })
 
+
 ### Markovchain Fitting For dataframe or matrix as an input
-matseq <- matrix(c("a", "b", "c", "a","b", "c"), nrow = 2, byrow = T)
+matseq <- matrix(c("a", "b", "c", NA ,"b", "c"), nrow = 2, byrow = T)
 
 # for matrix as input
 
 test_that("Markovchain Fit for matrix as input", {
-
-# for matrix as input    
+  
+  # for matrix as input    
   
   expect_equal(markovchainFit(matseq)$estimate@transitionMatrix, 
                matrix(c(0, 1, 0, 0, 0, 1, 0, 0, 0), nrow = 3, 
@@ -93,19 +96,21 @@ test_that("Markovchain Fit for matrix as input", {
                matrix(c(0, 1, 0, 0, 0, 1, 1/3, 1/3, 1/3), nrow = 3, 
                       byrow = TRUE, dimnames = list(c("a", "b", "c"), c("a", "b", "c"))))
   
-# for data frame as input
-    expect_equal(markovchainFit(as.data.frame(matseq))$estimate@transitionMatrix, 
-                 matrix(c(0, 1, 0, 0, 0, 1, 0, 0, 0), nrow = 3, 
-                        byrow = TRUE, dimnames = list(c("a", "b", "c"), c("a", "b", "c"))))
-    
-    expect_equal(markovchainFit(as.data.frame(matseq), sanitize = TRUE)$estimate@transitionMatrix, 
-                 matrix(c(0, 1, 0, 0, 0, 1, 1/3, 1/3, 1/3), nrow = 3, 
-                        byrow = TRUE, dimnames = list(c("a", "b", "c"), c("a", "b", "c"))))
-
+  # for data frame as input
+  expect_equal(markovchainFit(as.data.frame(matseq))$estimate@transitionMatrix, 
+               matrix(c(0, 1, 0, 0, 0, 1, 0, 0, 0), nrow = 3, 
+                      byrow = TRUE, dimnames = list(c("a", "b", "c"), c("a", "b", "c"))))
+  
+  expect_equal(markovchainFit(as.data.frame(matseq), sanitize = TRUE)$estimate@transitionMatrix, 
+               matrix(c(0, 1, 0, 0, 0, 1, 1/3, 1/3, 1/3), nrow = 3, 
+                      byrow = TRUE, dimnames = list(c("a", "b", "c"), c("a", "b", "c"))))
+  
 })
 
+
+
 ### Markovchain Fitting(mle) with sanitize parameter
-mle_sequence <- c("a", "b", "b", "a", "a", "a", "b", "b", "b", "a", "a", "b", "a", "a", "b", "c")
+mle_sequence <- c("a", "b", NA, "b", "b", "a", "a", "a", "b", "b", NA, "b", "b", "a", "a", "b", "a", "a", "b", "c")
 mle_fit1 <- markovchainFit(mle_sequence)
 mle_fit2 <- markovchainFit(mle_sequence, sanitize = TRUE)
 
@@ -126,7 +131,7 @@ test_that("MarkovchainFit MLE", {
 })
 
 ### Markovchain Fitting(laplace) with sanitize parameter
-lap_sequence <- c("a", "b", "b", "a", "a", "a", "b", "b", "b", "a", "a", "b", "a", "a", "b", "c")
+mle_sequence <- c("a", "b", NA, "b", "b", "a", "a", "a", "b", "b", NA, "b", "b", "a", "a", "b", "a", "a", "b", "c")
 lap_fit1 <- markovchainFit(lap_sequence, "laplace")
 lap_fit2 <- markovchainFit(lap_sequence, "laplace", sanitize = TRUE)
 
@@ -143,19 +148,20 @@ test_that("Markovchain Laplace", {
 })
 
 ### Markovchain Fitting when some states are not present in the given sequence
-mix_seq <- c("a", "b", "b", "a", "a", "a", "b", "b", "b", "a", "a", "b", "a", "a", "b", "c")
+mix_seq <- c("a", "b", NA, "b", "b", "a", "a", "a", "b", "b", NA, "b", "b", "a", "a", "b", "a", "a", "b", "c")
 
 mix_fit1 <- markovchainFit(mix_seq, "mle", sanitize = TRUE, possibleStates = c("d"))
 mix_fit2 <- markovchainFit(mix_seq, "laplace", sanitize = TRUE, possibleStates = c("d")) 
 mix_fit3 <- markovchainFit(mix_seq, "map", sanitize = TRUE, possibleStates = c("d")) 
+
 
 test_that("Mixture of Markovchain Fitting", {
   expect_equal(mix_fit2$estimate@transitionMatrix, 
                matrix(c(.5, .5, 0, 0, 3/7, 3/7, 1/7, 0,
                         1/4, 1/4, 1/4, 1/4, 1/4, 1/4, 1/4, 1/4), nrow = 4, byrow = TRUE,
                       dimnames = list(c("a", "b", "c", "d"), c("a", "b", "c", "d"))
-                      )
-              )
+               )
+  )
   
   expect_equal(mix_fit1$estimate@transitionMatrix, 
                matrix(c(.5, .5, 0, 0, 3/7, 3/7, 1/7, 0,
@@ -173,8 +179,9 @@ test_that("Mixture of Markovchain Fitting", {
   
 })
 
+
 ### Test for createSequenceMatrix
-rsequence <- c("a", "b", "b", "a", "a", "a", "b", "b", "b", "a", "a", "b", "a", "a", "b", "c")
+rsequence <- c("a", "b", NA, "b", "b", "a", "a", "a", "b", "b", NA, "b", "b", "a", "a", "b", "a", "a", "b", "c")
 
 test_that("createSequenceMatrix : Permutation of parameters",{
   expect_equal(createSequenceMatrix(rsequence, FALSE, FALSE), 
@@ -195,7 +202,7 @@ test_that("createSequenceMatrix : Permutation of parameters",{
 })
 
 ### Test for createSequenceMatrix : input nx2 matrix
-data <- matrix(c("a", "a", "b", "a", "b", "a", "b", "a", "a", "a", "a", "b"), ncol = 2,
+data <- matrix(c("a", "a", "b", "a", "b", "a", "b", "a", NA, "a", "a", "a", "a", "b", NA, "b"), ncol = 2,
                byrow = TRUE)
 
 test_that("createSequenceMatrix : input as matrix",{

--- a/tests/testthat/testBasic1.R
+++ b/tests/testthat/testBasic1.R
@@ -131,7 +131,7 @@ test_that("MarkovchainFit MLE", {
 })
 
 ### Markovchain Fitting(laplace) with sanitize parameter
-mle_sequence <- c("a", "b", NA, "b", "b", "a", "a", "a", "b", "b", NA, "b", "b", "a", "a", "b", "a", "a", "b", "c")
+lap_sequence <- c("a", "b", NA, "b", "b", "a", "a", "a", "b", "b", NA, "b", "b", "a", "a", "b", "a", "a", "b", "c")
 lap_fit1 <- markovchainFit(lap_sequence, "laplace")
 lap_fit2 <- markovchainFit(lap_sequence, "laplace", sanitize = TRUE)
 

--- a/vignettes/an_introduction_to_markovchain_package.Rnw
+++ b/vignettes/an_introduction_to_markovchain_package.Rnw
@@ -1077,6 +1077,7 @@ as code below shows.
 createSequenceMatrix(stringchar = weathersOfDays)
 @
 
+\code{stringchar} could contain \code{NA} values, and the transitions containing \code{NA} would be ignored.
 
 An issue occurs when the sample contains only one realization of a state (say $X_{\beta}$) which is located at the end of the data sequence, since it yields to a row of zero (no sample to estimate the conditional
 distribution of the transition). In this case the estimated transition matrix is
@@ -1216,6 +1217,7 @@ markovchainListFit(data=mylist)
 @
 
 
+If any transition contains \code{NA}, it will be ignored in the results.
 
 
 


### PR DESCRIPTION
I have solved the issue with the first approach of no transition at all that we discussed yesterday.

I've created an auxiliary function in `src/mapFitFunctionsSAI.h` called `clean_nas`, that given a character vector cleans the `NA` values to get the possible states of the markov chain. I'm calling that function inside `_mcFitMap` and `createSequenceMatrix`. Maybe it's not the right place for the function.

It has been necessary to modify `_loglikelihood` to treat `NA` too.

I've modified the tests for testing the modifications. For example, for a given sequence:
  
  ```
sequence <- c("a", "b", "a", "a", "a")
```

I've introduced an `NA` in a given position duplicating the previous state to the `NA` after the `NA`, in order to get same transitions as before:

```
sequence <- c("a", "b", "a", "a", NA, "a", "a")
```

I haven't modified the rest of the checking process. `markovchainFit` and `createSequenceMatrix` seem to be working fine. The modifications made to `createSequenceMatrix` should solve the issue for `markovchainListFit` as well.

