### PR TITLE
Revert "changes for #115"

### DIFF
--- a/R/0_classesAndMethods.R
+++ b/R/0_classesAndMethods.R
@@ -416,7 +416,7 @@ setMethod("steadyStates","markovchain",
   out<-matrix(0, nrow=numRecClasses, ncol = dim(object))
   colnames(out)<-names(object)
   #getting their steady states
-  partialOutput<-t(eigen(Msub)$vectors[,zapsmall(eigen(Msub)$values == 1)]) / colSums(eigen(Msub)$vectors[,zapsmall(eigen(Msub)$values == 1)])
+  partialOutput<-t(eigen(Msub)$vectors[,eigen(Msub)$values == 1]) / colSums(eigen(Msub)$vectors[,eigen(Msub)$values == 1])
   colnames(partialOutput)<-recurrentClassesNames
   #allocating to their columns
   out[,colnames(out) %in% recurrentClassesNames]<-partialOutput

--- a/man/steadyStates.Rd
+++ b/man/steadyStates.Rd
@@ -23,8 +23,6 @@ This method returns the stationary vector in matricial form of a markovchain obj
 The steady states are identified starting from which eigenvectors correspond 
       to identity eigenvalues and then normalizing them to sum up to unity. When negative values are found 
       in the matrix, the eigenvalues extraction is performed on the recurrent classes submatrix.
-      
-The \code{steadystates} function also handles the case when no eigen value comes out to be exactly 1. In such a case, it uses \code{zapsmall} rounding function to ensure that atleast one eigen value is equal to 1 (which theoritically is true.)
 }
 \examples{
 statesNames <- c("a", "b", "c")

--- a/vignettes/complicateSteadyStates.Rmd
+++ b/vignettes/complicateSteadyStates.Rmd
@@ -244,5 +244,3 @@ t(eigen(Msub)$vectors[,eigen(Msub)$values >= 1]) / colSums(eigen(Msub)$vectors[,
 ```
 
 The `steadyStates` function in [@pkg:markovchain] implements the abovementioned algorithm when negative values are found in the eigenvectors of the full matrix corresponding to unitary eigenvalues.
-
-The `steadystates` function also handles the case when no eigen value comes out to be exactly 1. In such a case, it uses `zapsmall` rounding function to ensure that atleast one eigen value is equal to 1 (which theoritically is true.) 


### PR DESCRIPTION
Reverts spedygiorgio/markovchain#120


  Loading required package: survival
  testthat results ================================================================
  OK: 93 SKIPPED: 0 FAILED: 2
  1. Failure: Check steadyStates (@testSteadyStates.R#38) 
  2. Failure: Check steadyStates (@testSteadyStates.R#42) 
  
  Error: testthat unit tests failed
  In addition: Warning message:
  In data(cav) : data set 'cav' not found
  Execution halted
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in 'inst/doc' ... OK
* checking re-building of vignette outputs ... OK
* DONE
Status: 1 ERROR, 1 NOTE

See
  'Z://markovchain.Rcheck/00check.log'
for details.

R CMD check results
1 error  | 0 warnings | 1 note 
checking tests ... ERROR
  Running 'testthat.R'
Running the tests in 'tests/testthat.R' failed.
Last 13 lines of output:
  [6]  0 - 0.5 == -0.5
  [8]  0 - 0.5 == -0.5
  [10] 1 - 0.0 ==  1.0
  
  
  Loading required package: survival
  testthat results ================================================================
  OK: 93 SKIPPED: 0 FAILED: 2
  1. Failure: Check steadyStates (@testSteadyStates.R#38) 
  2. Failure: Check steadyStates (@testSteadyStates.R#42) 