### PR TITLE
Solves valgrind leaks of memory

### DIFF
--- a/src/2_probabilistic.cpp
+++ b/src/2_probabilistic.cpp
@@ -429,35 +429,38 @@ int period(S4 object) {
   } else {
     NumericMatrix P = object.slot("transitionMatrix");
     int n = P.ncol();
-    arma::vec v(n);
     std::vector<double> r, T(1), w;
-    v[0] = 1;
     int d = 0, m = T.size(), i = 0, j = 0;
-    while(m>0 && d!=1) {
-      i = T[0];
-      T.erase(T.begin());
-      w.push_back(i);
-      j = 0;
-      while(j < n) {
-        if(P(i,j) > 0) {
-          r.insert(r.end(), w.begin(), w.end());
-          r.insert(r.end(), T.begin(), T.end());
-          double k = 0;
-          for(std::vector<double>::iterator it = r.begin(); it != r.end(); it ++) 
-            if(*it == j) k ++;
-          if(k > 0) {
-             int b = v[i] + 1 - v[j];
-             d = gcd(d, b);
-          } else {
-            T.push_back(j);
-            v[j] = v[i] + 1;
+    
+    if (n > 0) {
+      arma::vec v(n);
+      v[0] = 1;
+      while(m>0 && d!=1) {
+        i = T[0];
+        T.erase(T.begin());
+        w.push_back(i);
+        j = 0;
+        while(j < n) {
+          if(P(i,j) > 0) {
+            r.insert(r.end(), w.begin(), w.end());
+            r.insert(r.end(), T.begin(), T.end());
+            double k = 0;
+            for(std::vector<double>::iterator it = r.begin(); it != r.end(); it ++) 
+              if(*it == j) k ++;
+            if(k > 0) {
+               int b = v[i] + 1 - v[j];
+               d = gcd(d, b);
+            } else {
+              T.push_back(j);
+              v[j] = v[i] + 1;
+            }
           }
+          j ++;
         }
-        j ++;
+        m = T.size();
       }
-      m = T.size();
     }
-    v = v - floor(v/d)*d;
+    // v = v - floor(v/d)*d;
     return d;
   }
 }


### PR DESCRIPTION
The function I believe is causing the errors is the function `period` from the file `2_probabilistic.cpp`. I believe there are two main issues with that function:

* It declares a vector `arma::vec v(n)`; without even checking if the size is not 0
* It assigns `v = v - floor(v/d)*d`; just before the return, and I think in some cases d could be 0 and that would cause an error.

I've modified those two details and I've done a valgrind check getting no errors, and a `check --as-cran` to test that everything is still working with the package as expected.

I've attached the log of the valgrind errors.


[valgrind-log.txt](https://github.com/spedygiorgio/markovchain/files/2061933/valgrind-log.txt)

