### PR TITLE
`documentclass: jss` is required in the current CRAN version of rticles

### DIFF
--- a/vignettes/an_introduction_to_markovchain_package.Rmd
+++ b/vignettes/an_introduction_to_markovchain_package.Rmd
@@ -50,6 +50,7 @@ vignette: >
 keywords:
   plain: [discrete time Markov chains, continuous time Markov chains, transition matrices, communicating classes, periodicity, first passage time, stationary distributions]
   formatted: [discrete time Markov chains, continuous time Markov chains, transition matrices, communicating classes, periodicity, first passage time, stationary distributions]
+documentclass: jss
 classoption: nojss
 bibliography: markovchainBiblio.bib
 pkgdown:

--- a/vignettes/higher_order_markov_chains.Rmd
+++ b/vignettes/higher_order_markov_chains.Rmd
@@ -43,6 +43,7 @@ vignette: >
 keywords:
   plain: [Higher order Markov chains]
   formatted: [Higher order Markov chains]
+documentclass: jss
 classoption: nojss
 bibliography: markovchainBiblio.bib
 pkgdown:


### PR DESCRIPTION
This PR fixes the issues listed here: https://cran.rstudio.com/web/checks/check_results_markovchain.html

The document class is no longer hard-coded in `rticles::jss_article()`. Thanks!