### PR TITLE
MFPT to C++

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -406,6 +406,10 @@ priorDistribution <- function(transMatr, hyperparam = matrix()) {
     .Call(`_markovchain_steadyStates`, obj)
 }
 
+.absorbingStatesRcpp <- function(obj) {
+    .Call(`_markovchain_absorbingStates`, obj)
+}
+
 .isProbability <- function(prob) {
     .Call(`_markovchain_isProb`, prob)
 }

--- a/R/probabilistic.R
+++ b/R/probabilistic.R
@@ -56,7 +56,7 @@ is.accessible <- function(object, from, to) {
 # a markov chain is irreducible if it is composed of only one communicating class
 
 #' @name is.irreducible
-#' @title Function to check if a Markov chain is irreducible
+#' @title Function to check if a Markov chain is irreducible (i.e. ergodic)
 #' @description This function verifies whether a \code{markovchain} object transition matrix 
 #'              is composed by only one communicating class.
 #' @param object A \code{markovchain} object
@@ -78,10 +78,7 @@ is.accessible <- function(object, from, to) {
 #' is.irreducible(mcA)
 #' @export
 is.irreducible <- function(object) {
-  # This function will return a list of communicating classes 
-  commClasses <- .communicatingClassesRcpp(object)
-  # The markov chain is irreducible iff has only a single communicating class
-  return(length(commClasses) == 1)
+  .isIrreducibleRcpp(object)
 }
 
 # what this function will do?

--- a/R/probabilistic.R
+++ b/R/probabilistic.R
@@ -331,15 +331,7 @@ setMethod("recurrentStates", "markovchain", function(object) {
 setGeneric("absorbingStates", function(object) standardGeneric("absorbingStates"))
 
 setMethod("absorbingStates", "markovchain", function(object) {
-    n <- dim(object)
-    
-    whichAbsorbing <- which(
-      sapply(1:n, function(i) { 
-        isTRUE(all.equal(object@transitionMatrix[i, i], 1)) 
-      })
-    )
-    
-    object@states[whichAbsorbing]
+    .absorbingStatesRcpp(object)
   }
 )
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -494,6 +494,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// absorbingStates
+CharacterVector absorbingStates(S4 obj);
+RcppExport SEXP _markovchain_absorbingStates(SEXP objSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< S4 >::type obj(objSEXP);
+    rcpp_result_gen = Rcpp::wrap(absorbingStates(obj));
+    return rcpp_result_gen;
+END_RCPP
+}
 // isProb
 bool isProb(double prob);
 RcppExport SEXP _markovchain_isProb(SEXP probSEXP) {
@@ -644,6 +655,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_markovchain_hittingProbabilities", (DL_FUNC) &_markovchain_hittingProbabilities, 1},
     {"_markovchain_canonicForm", (DL_FUNC) &_markovchain_canonicForm, 1},
     {"_markovchain_steadyStates", (DL_FUNC) &_markovchain_steadyStates, 1},
+    {"_markovchain_absorbingStates", (DL_FUNC) &_markovchain_absorbingStates, 1},
     {"_markovchain_isProb", (DL_FUNC) &_markovchain_isProb, 1},
     {"_markovchain_isStochasticMatrix", (DL_FUNC) &_markovchain_isStochasticMatrix, 2},
     {"_markovchain_isProbVector", (DL_FUNC) &_markovchain_isProbVector, 1},

--- a/src/probabilistic.cpp
+++ b/src/probabilistic.cpp
@@ -1128,3 +1128,53 @@ CharacterVector absorbingStates(S4 obj) {
     
   return absorbing;
 }
+
+// [[Rcpp::export(.absorbingStatesRcpp)]]
+NumericMatrix meanFirstPassageTime(S4 obj) {
+  NumericMatrix transitionMatrix = obj.slot("transitionMatrix");
+  CharacterVector states = obj.slot("states");
+// [[Rcpp::export(.isIrreducibleRcpp)]]
+bool isIrreducible(S4 obj) {
+  List commClasses = communicatingClasses(obj);
+  // The markov chain is irreducible iff has only a single communicating class
+  return commClasses.size() == 1;
+}
+  bool byrow = obj.slot("byrow");
+  int numStates = states.size();
+  NumericMatrix passageTimes(numStates, numStates);
+  unordered_set<int> absorbing;
+    
+  if (!byrow)
+    transitionMatrix = transpose(transitionMatrix);
+  
+  for (int i = 0; i < numStates; ++i)
+    if (approxEqual(transitionMatrix(i, i), 1))
+      absorbing.insert(i);
+    
+  int s = numStates - absorbing.size();
+  int k = 0;
+  mat toInvert(s, s);
+  
+  for (int i = 0; i < numStates; ++i) {
+    if (absorbing.count(i) == 0) {
+      
+      for (int j = 0; j < numStates; ++j)
+        toInvert(k, j) = transitionMatrix(i, j);
+      
+      toInvert(k, k) -= 1;
+      ++k;
+    }
+  }
+  
+  solve(inv(toInvert, )
+  
+  
+  return absorbing;
+}
+
+// [[Rcpp::export(.isIrreducibleRcpp)]]
+bool isIrreducible(S4 obj) {
+  List commClasses = .communicatingClassesRcpp(obj);
+  // The markov chain is irreducible iff has only a single communicating class
+  return commClasses.size() == 1;
+}

--- a/src/probabilistic.cpp
+++ b/src/probabilistic.cpp
@@ -1112,3 +1112,19 @@ NumericMatrix steadyStates(S4 obj) {
   return result;
 }
 
+
+// This method is agnostic on whether the matrix is stochastic 
+// by rows or by columns, we just need the diagonal
+// [[Rcpp::export(.absorbingStatesRcpp)]]
+CharacterVector absorbingStates(S4 obj) {
+  NumericMatrix transitionMatrix = obj.slot("transitionMatrix");
+  CharacterVector states = obj.slot("states");
+  CharacterVector absorbing;
+  int numStates = states.size();
+  
+  for (int i = 0; i < numStates; ++i)
+    if (approxEqual(transitionMatrix(i, i), 1))
+      absorbing.push_back(states(i));
+    
+  return absorbing;
+}


### PR DESCRIPTION
Ports `meanFirstPassageTime` to `Rcpp` along with all auxiliary possible methods.

If we aim to create a C++ library that the R package and a possible Python package use as their internal implementation, we have to port as much R code to C++ as possible.