### PR TITLE
For verifyEmpiricalToTheoretical: Reject null hypothesis if a 0 in the object is >0 in the data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
     person("Vandit", "Jain", role = "ctb"),
     person("Toni", "Giorgino", role="ctb", comment = c(ORCID = "0000-0001-6449-0596")),
     person("Richèl J.C.", "Bilderbeek", role = "ctb", comment = c(ORCID = "0000-0003-1107-7049")),
-    person("Daniel", "Ebbert", email = "daniel@ebbert.nrw", role = "ctb", comment = c(ORCID = "0000-0003-3666-7205"))
+    person("Daniel", "Ebbert", email = "daniel@ebbert.nrw", role = "ctb", comment = c(ORCID = "0000-0003-3666-7205")),
     person("Shreyash", "Maheshwari", email = "coolshreysh1000@gmail.com", role = "ctb")
   )
 Maintainer: Giorgio Alfredo Spedicato <spedicato_giorgio@yahoo.it>

--- a/R/statisticalTests.R
+++ b/R/statisticalTests.R
@@ -362,7 +362,8 @@ assessStationarity <- function(sequence, nblocks, verbose = TRUE) {
 #' @title test whether an empirical transition matrix is compatible to a theoretical one
 #' 
 #' @description This function tests whether an empirical transition matrix is statistically compatible
-#' with a theoretical one. It is a chi-square based test
+#' with a theoretical one. It is a chi-square based test. In case a cell in the empirical transition matrix is >0
+#' that is 0 in the theoretical transition matrix the null hypothesis is rejected.
 #' 
 #' @rdname statisticalTests
 #' @family statisticalTests
@@ -370,7 +371,8 @@ assessStationarity <- function(sequence, nblocks, verbose = TRUE) {
 #' @param data matrix, character or list to be converted in a raw transition matrix
 #' @param object a markovchain object
 #'
-#' @return a list with following slots: statistic (the chi - square statistic), dof (degrees of freedom), and corresponding p-value
+#' @return a list with following slots: statistic (the chi - square statistic), dof (degrees of freedom), and corresponding p-value. In case a cell in the empirical transition matrix is >0
+#' that is 0 in the theoretical transition matrix the null hypothesis is rejected. In that case a p-value of 0 and statistic and dof of NA are returned.
 #' @export
 #'
 #' @examples

--- a/R/statisticalTests.R
+++ b/R/statisticalTests.R
@@ -405,32 +405,46 @@ verifyEmpiricalToTheoretical <- function(data, object, verbose = TRUE) {
   data <- data[match(rownames(data),names(object)),] #matching rows
   data <- data[,match(colnames(data),names(object))] #matching cols
   
-  f_i_dot <-colSums(data)
-  
-  statistic <- 0
-  
-  for (i in 1:dim(object)) {
-    for (j in 1:dim(object)) {
-      if (data[i, j]>0&object[i, j]>0) statistic <- statistic + data[i, j]*log(data[i, j]/(f_i_dot[i]*object[i, j]))
+  if (sum((data == 0) == (object@transitionMatrix == 0)) == (nrow(data) * ncol(data))) {
+    f_i_dot <-colSums(data)
+    
+    statistic <- 0
+    
+    for (i in 1:dim(object)) {
+      for (j in 1:dim(object)) {
+        if (data[i, j]>0&object[i, j]>0) statistic <- statistic + data[i, j]*log(data[i, j]/(f_i_dot[i]*object[i, j]))
+      }
     }
-  }
-  
-  statistic <- statistic * 2
-  
-  null_elements <- sum(object@transitionMatrix == 0)
-  
-  dof <- dim(object) * (dim(object) - 1) - null_elements #r(r-1) - c, c null element ob objects
-  
-  p.value <- 1 - pchisq(q = statistic,df = dof)
-  
-  if (verbose == TRUE) {
-    cat("Testing whether the\n");print(data);cat("transition matrix is compatible with\n");print(object@transitionMatrix);print("theoretical transition matrix")
-    cat("ChiSq statistic is",statistic,"d.o.f are",dof,"corresponding p-value is",p.value,"\n")  
+    
+    statistic <- statistic * 2
+    
+    null_elements <- sum(object@transitionMatrix == 0)
+    
+    dof <- dim(object) * (dim(object) - 1) - null_elements #r(r-1) - c, c null element ob objects
+    
+    p.value <- 1 - pchisq(q = statistic,df = dof)
+    
+    if (verbose == TRUE) {
+      cat("Testing whether the\n");print(data);cat("transition matrix is compatible with\n");print(object@transitionMatrix);print("theoretical transition matrix")
+      cat("ChiSq statistic is",statistic,"d.o.f are",dof,"corresponding p-value is",p.value,"\n")  
+    }
+    
+    out <- list(statistic = statistic, dof = dof,pvalue = p.value)
+  } else {
+    statistic <- NA
+    dof <- NA
+    p.value <- 0
+    
+    if (verbose == TRUE) {
+      cat("Testing whether the\n");print(data);cat("transition matrix is compatible with\n");print(object@transitionMatrix);print("theoretical transition matrix")
+      cat("ChiSq statistic is",statistic,"d.o.f are",dof,"corresponding p-value is",p.value,"\n")
+      cat("At least one transition is >0 in the data that is 0 in the object. Therefore the null hypothesis is rejected. \n") 
+    }
+    
+    out <- list(statistic = statistic, dof = dof,pvalue = p.value)
   }
 
   #return output
-  out <- list(statistic = statistic, dof = dof,pvalue = p.value)
-  
   return(out)
 }
 

--- a/man/statisticalTests.Rd
+++ b/man/statisticalTests.Rd
@@ -34,7 +34,8 @@ verifyHomogeneity(inputList, verbose = TRUE)
 \value{
 Verification result
 
-a list with following slots: statistic (the chi - square statistic), dof (degrees of freedom), and corresponding p-value
+a list with following slots: statistic (the chi - square statistic), dof (degrees of freedom), and corresponding p-value. In case a cell in the empirical transition matrix is >0
+that is 0 in the theoretical transition matrix the null hypothesis is rejected. In that case a p-value of 0 and statistic and dof of NA are returned.
 
 a list of transition matrices?
 }
@@ -43,7 +44,8 @@ These functions verify the Markov property, assess
              the order and stationarity of the Markov chain.
 
 This function tests whether an empirical transition matrix is statistically compatible
-with a theoretical one. It is a chi-square based test
+with a theoretical one. It is a chi-square based test. In case a cell in the empirical transition matrix is >0
+that is 0 in the theoretical transition matrix the null hypothesis is rejected.
 
 Verifies that the s elements in the input list belongs to the same DTMC
 }

--- a/tests/testthat/testStatisticalTests.R
+++ b/tests/testthat/testStatisticalTests.R
@@ -1,0 +1,92 @@
+context("Checking verifyEmpiricalToTheoretical")
+
+example_results <- list(statistic = 6.551795, dof = 6, pvalue = 0.3642899)
+
+test_that("Sequence data input is computed correctly", {
+  sequence <- c(0,1,2,2,1,0,0,0,0,0,0,1,2,2,2,1,0,0,1,0,0,0,0,0,0,1,1,
+  2,0,0,2,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0,0,2,1,0,
+  0,2,1,0,0,0,0,0,0,1,1,1,2,2,0,0,2,1,1,1,1,2,1,1,1,1,1,1,1,1,1,0,2,
+  0,1,1,0,0,0,1,2,2,0,0,0,0,0,0,2,2,2,1,1,1,1,0,1,1,1,1,0,0,2,1,1,
+  0,0,0,0,0,2,2,1,1,1,1,1,2,1,2,0,0,0,1,2,2,2,0,0,0,1,1)
+   
+  mc <- matrix(c(5/8,1/4,1/8,1/4,1/2,1/4,1/4,3/8,3/8),
+               byrow = TRUE,
+               nrow = 3)
+  rownames(mc) <- colnames(mc) <- 0:2
+  theoreticalMc <- as(mc, "markovchain")
+   
+  result <- verifyEmpiricalToTheoretical(data = sequence, object = theoreticalMc, verbose = FALSE)
+  
+  expect_equivalent(example_results, result)
+})
+
+test_that("Matrix data input is computed correctly", {
+  matrix <- matrix(c(51, 11, 8,
+                     12, 31, 9,
+                     6, 11, 10),
+                   byrow = TRUE,
+                   nrow = 3)
+  rownames(matrix) <- colnames(matrix) <- 0:2
+  
+  mc <- matrix(c(5/8,1/4,1/8,1/4,1/2,1/4,1/4,3/8,3/8),
+               byrow = TRUE,
+               nrow = 3)
+  rownames(mc) <- colnames(mc) <- 0:2
+  theoreticalMc <- as(mc, "markovchain")
+  
+  result <- verifyEmpiricalToTheoretical(data = matrix, object = theoreticalMc, verbose = FALSE)
+  
+  expect_equivalent(example_results, result)
+})
+
+test_that("Input data sequences can contain missing states", {
+  mc <- matrix(c(
+    1 / 10, 7 / 10, 1 / 10, 1 / 10,
+    1 / 10, 1 / 10, 4 / 10, 4 / 10,
+    1 / 10, 5 / 10, 1 / 10, 3 / 10,
+    1 / 10, 5 / 10, 3 / 10, 1 / 10
+  ),
+  byrow = TRUE,
+  nrow = 4
+  )
+  rownames(mc) <- c(1:4)
+  colnames(mc) <- c(1:4)
+  theoreticalMc <- as(mc, "markovchain")
+  
+  sequence <- c(1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1)
+  
+  result <- verifyEmpiricalToTheoretical(data = sequence, object = theoreticalMc, verbose = FALSE)
+  
+  expect_true(exists("result"))
+})
+
+test_that("Null hypothesis is rejected when 0 in the object matrix is not 0 in the data matrix", {
+  example <- matrix(c(
+    0.6105, 0.1665, 0.0393, 0.1837,
+    0.1374, 0.5647, 0.0637, 0.2342,
+    0.3010, 0.1142, 0.3218, 0.2630,
+    0.2595, 0.3109, 0.0000, 0.4296
+  ),
+  byrow = TRUE,
+  nrow = 4
+  )
+  rownames(example) <- c(1:4)
+  colnames(example) <- c(1:4)
+  
+  mc <- matrix(c(
+    0.00, 1.00, 0.00, 0.00,
+    0.00, 0.00, 0.50, 0.50,
+    0.00, 0.75, 0.00, 0.25,
+    0.00, 0.75, 0.25, 0.00
+  ),
+  byrow = TRUE,
+  nrow = 4
+  )
+  rownames(mc) <- c(1:4)
+  colnames(mc) <- c(1:4)
+  theoreticalMc <- as(mc, "markovchain")
+  
+  result <- verifyEmpiricalToTheoretical(data = example, object = theoreticalMc, verbose = FALSE)
+  
+  expect_equivalent(result$pvalue, 0)
+})


### PR DESCRIPTION
This pull request rewrites the verifyEmpiricalToTheoretical function. It is changed so that when the object contains a 0 in the transition matrix that is greater then 0 in the data the null hypothesis is rejected. In that case a p value of 0 is returned. Statistic and degrees of freedom are returned as NA. This would close issue #197 .