### PR TITLE
Fixes bug on reachability methods

### DIFF
--- a/src/probabilistic.cpp
+++ b/src/probabilistic.cpp
@@ -1200,27 +1200,14 @@ bool isRegular(S4 obj) {
   int m = transitions.ncol();
   mat probs(transitions.begin(), m, m, true);
   mat reachable;
-  // Let alias this as d
-  int positiveDiagonal = 0;
   auto arePositive = [](const double& x){ return x > 0; };
   
-  // Count positive elements in the diagonal
-  for (int i = 0; i < m; ++i)
-    if (probs(i, i) > 0)
-      ++positiveDiagonal;
   
   // Taken from the book: 
   // Matrix Analysis. Roger A.Horn, Charles R.Johnson. 2nd edition. 
-  // Corollary 8.5.8 and Theorem 8.5.9
-  //
-  // If A is irreducible and has 0 < d positive diagonal elements
-  //   A is regular and $A^{2m - d - 1} > 0
-  //
+  // Theorem 8.5.9
   // A is regular iff A^{m²- 2m + 2} > 0
-  if (positiveDiagonal > 0)
-    reachable = matrixPow(probs, 2*m - positiveDiagonal - 1);
-  else
-    reachable = matrixPow(probs, m*m - 2*m + 2);
+  reachable = matrixPow(probs, m*m - 2*m + 2);
   
   return allElements(reachable, arePositive);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -26,7 +26,7 @@ mat matrixPow(const mat& A, int n) {
   // Compute last = a + 1
   while (n > 0) {
     if ((n & 1) > 0)
-      result = result + partial;
+      result = result * partial;
     
     partial = partial * partial;
     n >>= 1;


### PR DESCRIPTION
Fixes #207

There was a bug where we were summing matrixes instead of multiplying them as they should, which affected all the reachability methods.