### PR TITLE
fix: use dynamic CRAN version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ devtools::install_github('spedygiorgio/markovchain')
 
 ![alt tag](https://travis-ci.org/spedygiorgio/markovchain.svg?branch=master)
 [![Downloads](http://cranlogs.r-pkg.org/badges/markovchain)](https://cran.r-project.org/package=markovchain)
- [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/markovchain)](https://cran.r-project.org/package=markovchain)
- [![Research software impact](http://depsy.org/api/package/cran/markovchain/badge.svg)](http://depsy.org/package/r/markovchain)
+[![CRAN_Status_Badge](https://img.shields.io/cran/v/markovchain?label=CRAN)](https://CRAN.R-project.org/package=markovchain)
+[![Research software impact](http://depsy.org/api/package/cran/markovchain/badge.svg)](http://depsy.org/package/r/markovchain)
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/spedygiorgio/markovchain/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/spedygiorgio/markovchain/actions/workflows/R-CMD-check.yaml)


### PR DESCRIPTION
## What changed
- Replace the legacy `r-pkg.org` CRAN version badge in `README.md` with a dynamic CRAN version badge served by Shields.
- Link the badge to the canonical CRAN package page.

## Why
The previous badge could display a stale CRAN version. The new badge retrieves the CRAN version dynamically, so the GitHub landing page does not require a repository change every time a new release is published to CRAN.

## Validation
- Confirmed the current CRAN release is `0.10.3` from CRAN package metadata.
- Compared the PR branch with `master`: one file changed (`README.md`), with only the badge URL/link changed.