### PR TITLE
test: add regression coverage for issue #148

### DIFF
--- a/tests/testthat/testByrowStructuralAnalysis.R
+++ b/tests/testthat/testByrowStructuralAnalysis.R
@@ -1,0 +1,41 @@
+context("Structural analysis with column-stochastic matrices")
+
+test_that("column-stochastic matrices preserve recurrent and transient classes", {
+  states <- as.character(0:4)
+  P <- matrix(
+    c(
+      1, 0, 0, 0, 0,
+      0.5, 0.5, 0, 0, 0,
+      0, 0.5, 0, 0.5, 0,
+      0, 0, 0.5, 0.5, 0,
+      0, 0, 0, 0, 1
+    ),
+    nrow = 5,
+    byrow = TRUE,
+    dimnames = list(states, states)
+  )
+
+  mc_byrow <- new(
+    "markovchain",
+    states = states,
+    transitionMatrix = P,
+    byrow = TRUE
+  )
+
+  mc_bycol <- new(
+    "markovchain",
+    states = states,
+    transitionMatrix = t(P),
+    byrow = FALSE
+  )
+
+  expect_equal(recurrentClasses(mc_byrow), recurrentClasses(mc_bycol))
+  expect_equal(transientClasses(mc_byrow), transientClasses(mc_bycol))
+  expect_equal(recurrentStates(mc_byrow), recurrentStates(mc_bycol))
+  expect_equal(transientStates(mc_byrow), transientStates(mc_bycol))
+
+  expect_equal(recurrentClasses(mc_bycol), list("0", "4"))
+  expect_equal(transientClasses(mc_bycol), list("1", "2", "3"))
+  expect_equal(recurrentStates(mc_bycol), c("0", "4"))
+  expect_equal(transientStates(mc_bycol), c("1", "2", "3"))
+})


### PR DESCRIPTION
## Summary
- add regression coverage for structural analysis of column-stochastic `markovchain` objects
- verify that recurrent/transient classes and states agree with the equivalent row-stochastic representation
- cover the behavior reported in #148 without changing production code

## Validation
The current implementation already normalizes `byrow = FALSE` matrices for structural analysis by transposing them before the graph analysis. This PR adds a regression test to prevent the reported class inversion from returning.

Closes #148