### PR TITLE
chore: sync feat/lumpability with master

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -304,6 +304,7 @@ markovchainFit <- function(data, method = "mle", byrow = TRUE, nboot = 10L, lapl
     .Call(`_markovchain_gcd`, a, b)
 }
 
+#' @name period
 #' @rdname structuralAnalysis
 #' 
 #' @export

--- a/src/probabilistic.cpp
+++ b/src/probabilistic.cpp
@@ -537,7 +537,7 @@ int gcd (int a, int b) {
 }
 
 // function to get the period of a DTMC
-
+//' @name period
 //' @rdname structuralAnalysis
 //' 
 //' @export


### PR DESCRIPTION
Synchronize `feat/lumpability` with the latest `master`, including the documentation fix merged in #260. This PR targets the feature branch only; it does not modify `master`. Merging it will bring `feat/lumpability` up to date before continuing CI validation for lumpability.