### PR TITLE
fix: harden TinyTeX setup in CI

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -49,15 +49,15 @@ jobs:
           needs: website
           cache: true
 
-      - name: Install TinyTeX
-        run: |
-          for i in 1 2 3; do
-            Rscript -e 'tinytex::install_tinytex()' && exit 0
-            echo "TinyTeX install attempt $i failed, retrying..."
-            sleep 20
-          done
-          exit 1
-        shell: bash
+      - id: tinytex
+        uses: r-lib/actions/setup-tinytex@v2
+        continue-on-error: true
+
+      - if: steps.tinytex.outcome == 'failure'
+        uses: r-lib/actions/setup-tinytex@v2
+
+      - name: Install additional LaTeX packages
+        run: tlmgr install grfext thumbpdf
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)


### PR DESCRIPTION
## Summary
- replace the manual TinyTeX bootstrap in `pkgdown` with `r-lib/actions/setup-tinytex@v2`, matching the R CMD check workflows
- keep a retry of the setup action for transient installation failures
- install the additional LaTeX packages through the configured `tlmgr`

## Why
The reported failure comes from a manual `tinytex::install_tinytex()` bootstrap that leaves `tlmgr` in a partially configured state (`already registered auxtree`) and never exposes a usable `pdflatex`. Using the maintained CI action avoids duplicating TinyTeX discovery/path/configuration logic and keeps the setup consistent across workflows.

## Scope
Only `.github/workflows/pkgdown.yaml` is changed. The current `R-CMD-check.yaml` on `master` already uses `setup-tinytex@v2`, so this PR removes the remaining inconsistent TinyTeX bootstrap from `pkgdown`.